### PR TITLE
Proposal to add a repository to host maven-archetype for SpotBugs plugin project

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2016 Kengo TODA
+Copyright 2017 SpotBugs team
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
As @iloveeclipse said in [his mail](https://mailman.cs.umd.edu/pipermail/findbugs-discuss/2016-November/004321.html), FindBugs had problem and could not build contributors community.

To build it for SpotBugs, I personally think that it is nice to _help developers to develop plugin_ more active. Because many of core SpotBugs developers are also plugin developers (fb-contrib, find-sec-bug, findbugs-slf4j etc.). Developing original plugin is really useful for developers to make their product stable, and it brings opportunity to read the implementation of SpotBugs too.

Now SpotBugs plugin is not so hard to develop, because it fixed a minor bug [which makes product complex](https://mailman.cs.umd.edu/pipermail/findbugs-discuss/2012-September/003633.html), and we also have a module to test with matchers. Then providing project template would help potential contributors to catch up how-to develop plugin, I believe. So I propose to host this project and merge this pull-request to start development as a team.

Note that, of course, documentation is also necessary. Let's improve both of manual and javadoc to get more contribution.
And for now I choose Apache License because I think this is basically nice for Java products, but LGPL v2.1/v3 and GPL v3 are also welcomed if we need to keep consistency with license of SpotBugs itself.