### PR TITLE
Add properties to generated pom.xml, to help m2e to find proper JDK

### DIFF
--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -9,6 +9,7 @@
   <properties>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
   <description>My SpotBugs plugin project</description>

--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -6,6 +6,11 @@
   <artifactId>${artifactId}</artifactId>
   <version>${version}</version>
 
+  <properties>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+  </properties>
+
   <description>My SpotBugs plugin project</description>
   <dependencies>
     <dependency>


### PR DESCRIPTION
Currently generated pom.xml has no property to specify source version and compiler target.
So m2e tries to use Java5, even though SpotBugs does not support Java7 or less.