### PR TITLE
Use xml-maven-plugin to validate findbugs.xml/messages.xml

### DIFF
--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -10,7 +10,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <spotbugsVersion>3.1.0-RC4</spotbugsVersion>
+    <spotBugsVersion>3.1.0-RC4</spotBugsVersion>
   </properties>
 
   <description>My SpotBugs plugin project</description>
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs</artifactId>
-      <version>${spotbugsVersion}</version>
+      <version>${spotBugsVersion}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -30,8 +30,51 @@
     <dependency>
       <groupId>com.github.spotbugs</groupId>
       <artifactId>test-harness</artifactId>
-      <version>${spotbugsVersion}</version>
+      <version>${spotBugsVersion}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>xml-maven-plugin</artifactId>
+        <version>1.0.1</version>
+        <executions>
+          <execution>
+            <id>validate-spotbugs-configuration</id>
+            <goals>
+              <goal>validate</goal>
+            </goals>
+            <configuration>
+              <validationSets>
+                <validationSet>
+                  <dir>src/main/resources</dir>
+                  <includes>
+                    <include>findbugs.xml</include>
+                  </includes>
+                  <systemId>findbugsplugin.xsd</systemId>
+                </validationSet>
+                <validationSet>
+                  <dir>src/main/resources</dir>
+                  <includes>
+                    <include>messages.xml</include>
+                  </includes>
+                  <systemId>messagecollection.xsd</systemId>
+                </validationSet>
+              </validationSets>
+            </configuration>
+          </execution>
+        </executions>
+        <dependencies>
+          <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs</artifactId>
+            <version>${spotBugsVersion}</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+    </plugins>
+  </build>
 </project>


### PR DESCRIPTION
I use the `xml-maven-plugin` in my own SpotBugs detectors to ensure that the `findbugs.xml`/`messages.xml` validates according to the XML Schemas shipped with SpotBugs.

WDYT? Is this a valuable addition to the archetype?