### PR TITLE
Append prefix to commit message

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,9 @@ updates:
   directory: "/"
   schedule:
     interval: daily
+  commit-message:
+    # dependencies for semantic-release won't affect behavior of the product
+    prefix: "build"
 - package-ecosystem: maven
   directory: "/"
   schedule:


### PR DESCRIPTION
The dependabot v2 does not add "build: " as its commit message prefix, so the PR cannot pass its check by Semantic Pull Request.

[The `commit-message` config is described at here](https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates#commit-message). I've also confirmed that [': ' will be added by dependabot](https://github.com/dependabot/dependabot-core/blob/92533d45e69aab0aa5b3bccf90b7668ed678b476/common/lib/dependabot/pull_request_creator/pr_name_prefixer.rb#L86-L87) after the configured prefix 'build'.