### PR TITLE
fix: use hamcrest' assertThat

### DIFF
--- a/src/main/resources/archetype-resources/src/test/java/MyDetectorTest.java
+++ b/src/main/resources/archetype-resources/src/test/java/MyDetectorTest.java
@@ -1,7 +1,7 @@
 package ${package};
 
 import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;


### PR DESCRIPTION
Avoid compiler's warning about deprecated API used.

https://github.com/junit-team/junit4/blob/HEAD/doc/ReleaseNotes4.13.md#pull-request-1150-deprecate-assertassertthat