### PR TITLE
Bump up Java to the latest LTS version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
           ref: ${{ steps.condval.outputs.value }}
       - uses: actions/setup-java@v4
         with:
-          java-version: 8
+          java-version: 21
           distribution: temurin
           server-id: ossrh
           server-username: MAVEN_USERNAME


### PR DESCRIPTION
Currently builds in topic branches are failing due to Java version mismatch. By this change, we will use the latest LTS Java version to build, so builds will work as expected.